### PR TITLE
fix(Staking, RoninValidatorSet): bumps addition gas to 6200

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,4 @@
 [submodule "lib/safe-smart-account"]
 	path = lib/safe-smart-account
 	url = https://github.com/safe-global/safe-smart-account
+	branch = v1.4.1

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 	path = lib/foundry-deployment-kit
 	url = https://github.com/axieinfinity/foundry-deployment-kit
 	branch = v0.2.0
+[submodule "lib/safe-smart-account"]
+	path = lib/safe-smart-account
+	url = https://github.com/safe-global/safe-smart-account

--- a/contracts/extensions/consumers/GlobalConfigConsumer.sol
+++ b/contracts/extensions/consumers/GlobalConfigConsumer.sol
@@ -3,8 +3,8 @@
 pragma solidity ^0.8.9;
 
 abstract contract GlobalConfigConsumer {
-  /// @dev The addition amount of gas sending along in external calls. Total gas stipend is added with default 7300 gas.
-  uint256 public constant DEFAULT_ADDITION_GAS = 7300;
+  /// @dev The addition amount of gas sending along in external calls. Total gas stipend is added with default 2300 gas.
+  uint256 public constant DEFAULT_ADDITION_GAS = 6200;
   /// @dev The length of a period in second.
   uint256 public constant PERIOD_DURATION = 1 days;
 }

--- a/contracts/extensions/consumers/GlobalConfigConsumer.sol
+++ b/contracts/extensions/consumers/GlobalConfigConsumer.sol
@@ -3,8 +3,8 @@
 pragma solidity ^0.8.9;
 
 abstract contract GlobalConfigConsumer {
-  /// @dev The addition amount of gas sending along in external calls. Total gas stipend is added with default 2300 gas.
-  uint256 public constant DEFAULT_ADDITION_GAS = 6200;
+  /// @dev The addition amount of gas sending along in external calls. Total gas stipend is added with default 7300 gas.
+  uint256 public constant DEFAULT_ADDITION_GAS = 7300;
   /// @dev The length of a period in second.
   uint256 public constant PERIOD_DURATION = 1 days;
 }

--- a/contracts/extensions/consumers/GlobalConfigConsumer.sol
+++ b/contracts/extensions/consumers/GlobalConfigConsumer.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.9;
 
 abstract contract GlobalConfigConsumer {
   /// @dev The addition amount of gas sending along in external calls. Total gas stipend is added with default 2300 gas.
-  uint256 public constant DEFAULT_ADDITION_GAS = 1200;
+  uint256 public constant DEFAULT_ADDITION_GAS = 6200;
   /// @dev The length of a period in second.
   uint256 public constant PERIOD_DURATION = 1 days;
 }

--- a/foundry.toml
+++ b/foundry.toml
@@ -14,7 +14,7 @@ libs = ['lib', 'node_modules/@openzeppelin', 'node_modules/hardhat']
 solc = '0.8.25'
 use_literal_content = true
 extra_output = ["devdoc", "userdoc", "storagelayout"]
-evm_version = 'istanbul'
+evm_version = 'berlin'
 cache_path = 'cache_foundry'
 fs_permissions = [{ access = "read-write", path = "./" }]
 

--- a/remappings.txt
+++ b/remappings.txt
@@ -9,3 +9,4 @@ hardhat/=./node_modules/hardhat/
 solady/=lib/solady/src
 foundry-deployment-kit/=lib/foundry-deployment-kit/script
 contract-libs/=lib/contract-libs/src
+safe-smart-account/contracts/=lib/safe-smart-account/contracts/

--- a/test/foundry/extensions/MockRONTransferHelperConsumer_Berlin.sol
+++ b/test/foundry/extensions/MockRONTransferHelperConsumer_Berlin.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.9;
+
+import { RONTransferHelper } from "@ronin/contracts/extensions/RONTransferHelper.sol";
+
+contract MockRONTransferHelperConsumer_Berlin is RONTransferHelper {
+  uint256 public constant DEFAULT_ADDITION_GAS = 6200;
+
+  function sendRONLimitGas(address payable recipient, uint256 amount) public {
+    _unsafeSendRONLimitGas(recipient, amount, DEFAULT_ADDITION_GAS);
+  }
+}

--- a/test/foundry/extensions/MockRONTransferHelperConsumer_Istanbul.sol
+++ b/test/foundry/extensions/MockRONTransferHelperConsumer_Istanbul.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.9;
+
+import { RONTransferHelper } from "@ronin/contracts/extensions/RONTransferHelper.sol";
+
+contract MockRONTransferHelperConsumer_Istanbul is RONTransferHelper {
+  uint256 public constant DEFAULT_ADDITION_GAS = 1200;
+
+  function sendRONLimitGas(address payable recipient, uint256 amount) public {
+    _unsafeSendRONLimitGas(recipient, amount, DEFAULT_ADDITION_GAS);
+  }
+}

--- a/test/foundry/extensions/RONTransferHelper.t.sol
+++ b/test/foundry/extensions/RONTransferHelper.t.sol
@@ -22,7 +22,6 @@ contract RONTransferHelperTest is Test {
 
   function testFuzz_RevertIf_SendIstanbulGasStipened_ToMultisigWallet_OnBerlin(uint256 value) public {
     vm.deal(address(istanbulRONTransfer), value);
-    address sender = vm.addr(0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80);
 
     vm.expectRevert();
     istanbulRONTransfer.sendRONLimitGas(payable(multisig), value);
@@ -30,7 +29,6 @@ contract RONTransferHelperTest is Test {
 
   function testFuzz_SendBerlinGasStipened_ToMultisigWallet_OnBerlin(uint256 value) public {
     vm.deal(address(berlinRONTransfer), value);
-    address sender = vm.addr(0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80);
 
     berlinRONTransfer.sendRONLimitGas(payable(multisig), value);
   }

--- a/test/foundry/extensions/RONTransferHelper.t.sol
+++ b/test/foundry/extensions/RONTransferHelper.t.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.9;
+
+import { SafeL2 } from "safe-smart-account/contracts/SafeL2.sol";
+import { MockRONTransferHelperConsumer_Berlin } from "./MockRONTransferHelperConsumer_Berlin.sol";
+import { MockRONTransferHelperConsumer_Istanbul } from "./MockRONTransferHelperConsumer_Istanbul.sol";
+
+import { Test } from "forge-std/Test.sol";
+import { console } from "forge-std/console.sol";
+
+contract RONTransferHelperTest is Test {
+  address multisig;
+  MockRONTransferHelperConsumer_Berlin berlinRONTransfer;
+  MockRONTransferHelperConsumer_Istanbul istanbulRONTransfer;
+
+  function setUp() public {
+    multisig = address(new SafeL2());
+    berlinRONTransfer = new MockRONTransferHelperConsumer_Berlin();
+    istanbulRONTransfer = new MockRONTransferHelperConsumer_Istanbul();
+  }
+
+  function testFuzz_RevertIf_SendIstanbulGasStipened_ToMultisigWallet_OnBerlin(uint256 value) public {
+    vm.deal(address(istanbulRONTransfer), value);
+    address sender = vm.addr(0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80);
+
+    vm.expectRevert();
+    istanbulRONTransfer.sendRONLimitGas(payable(multisig), value);
+  }
+
+  function testFuzz_SendBerlinGasStipened_ToMultisigWallet_OnBerlin(uint256 value) public {
+    vm.deal(address(berlinRONTransfer), value);
+    address sender = vm.addr(0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80);
+
+    berlinRONTransfer.sendRONLimitGas(payable(multisig), value);
+  }
+}


### PR DESCRIPTION
### Description
This PR bumps `DEFAULT_ADDITION_GAS` from 1200 to 6200 to support transferring funds to multisig wallet when Tripp HardFork activated.

The table below shows the following info:
- **Logic**: the logic is changed.
- **ABI**: the ABI is changed.
- **Init data**: new storage field is declared and needs initializing.
- **Dependent**: needs to be changed due to changes in other contracts.

| **Contract name**       | **Logic** | **ABI** | **Init data** | **Dependent** |
|-------------------------|:---------:|:-------:|:-------------:|:-------------:|
| FastFinalityTracking    |           |         |               |               |
| GovernanceAdmin         |           |         |               |               |
| Maintenance             |           |         |               |               |
| Profile                 |           |         |               |               |
| SlashIndicator          |           |         |               |               |
| Staking                 |     x      |         |               |               |
| StakingVesting          |           |         |               |               |
| ValidatorSet            |      x     |         |               |               |
| Random Beacon |         |     |  | |


### Checklist
- [x] I have chosen the base of the PR to the `release/**` branch.
- [x] I have named the PR following the format of `[contract_name] what_is_changed`, where `contract_name` is the list of changed contracts, separated by `|`, or is `*` if there is changed in more than 3 contracts
- [x] I have ticked in the `Contract changes` table to guide the deployer which contracts to be upgraded.
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [ ] I tested locally to make sure this feature/fix works
