### PR TITLE
hotfix: Fast Finality Tracking incorrectly normalize candidates stake amounts

### DIFF
--- a/contracts/libraries/LibArray.sol
+++ b/contracts/libraries/LibArray.sol
@@ -156,11 +156,12 @@ library LibArray {
    *
    */
   function findNormalizedSumAndPivot(
+    address[] memory cids,
     uint256[] memory values,
     uint256 divisor
   ) internal pure returns (uint256 normSum, uint256 pivot) {
     divisor = Math.min(values.length, divisor);
-    values = inplaceDescSort(values);
+    inplaceDescSortByValue(cids, values);
 
     uint256 sLeft;
     uint256 nLeft;

--- a/contracts/libraries/LibArray.sol
+++ b/contracts/libraries/LibArray.sol
@@ -153,15 +153,15 @@ library LibArray {
    *                                ^         ^        ^
    *                                a[2]      a[3]     a[4]
    *
-   *
+   * WARNING: This function modifies `cids` and `values`
    */
-  function findNormalizedSumAndPivot(
+  function inplaceFindNormalizedSumAndPivot(
     address[] memory cids,
     uint256[] memory values,
     uint256 divisor
   ) internal pure returns (uint256 normSum, uint256 pivot) {
     divisor = Math.min(values.length, divisor);
-    inplaceDescSortByValue(cids, values);
+    inplaceDescSortByValue({ self: cids, values: values });
 
     uint256 sLeft;
     uint256 nLeft;

--- a/contracts/ronin/fast-finality/FastFinalityTracking.sol
+++ b/contracts/ronin/fast-finality/FastFinalityTracking.sol
@@ -122,7 +122,7 @@ contract FastFinalityTracking is IFastFinalityTracking, Initializable, HasContra
       uint256[] memory stakeAmounts = staking.getManyStakingTotalsById({ poolIds: allCids });
       uint256 pivot;
 
-      (normalizedSum_, pivot) = LibArray.findNormalizedSumAndPivot({
+      (normalizedSum_, pivot) = LibArray.inplaceFindNormalizedSumAndPivot({
         cids: allCids,
         values: stakeAmounts,
         divisor: validator.maxValidatorNumber()

--- a/contracts/ronin/fast-finality/FastFinalityTracking.sol
+++ b/contracts/ronin/fast-finality/FastFinalityTracking.sol
@@ -122,8 +122,11 @@ contract FastFinalityTracking is IFastFinalityTracking, Initializable, HasContra
       uint256[] memory stakeAmounts = staking.getManyStakingTotalsById({ poolIds: allCids });
       uint256 pivot;
 
-      (normalizedSum_, pivot) =
-        LibArray.findNormalizedSumAndPivot({ values: stakeAmounts, divisor: validator.maxValidatorNumber() });
+      (normalizedSum_, pivot) = LibArray.findNormalizedSumAndPivot({
+        cids: allCids,
+        values: stakeAmounts,
+        divisor: validator.maxValidatorNumber()
+      });
 
       uint256[] memory normalizedStakeAmounts = LibArray.inplaceClip({ values: stakeAmounts, lower: 0, upper: pivot });
       for (uint256 i; i < allCids.length; ++i) {

--- a/logs/contract-code-sizes.log
+++ b/logs/contract-code-sizes.log
@@ -3,7 +3,7 @@
 | Address                                 | 0.086     | 24.49       |
 | ArrayReplaceLib                         | 0.086     | 24.49       |
 | Ballot                                  | 0.086     | 24.49       |
-| BaseGeneralConfig                       | 31.341    | -6.765      |
+| BaseGeneralConfig                       | 30.519    | -5.943      |
 | BridgeOperatorsBallot                   | 0.166     | 24.41       |
 | BridgeTrackingRecoveryLogic             | 0.913     | 23.663      |
 | ECDSA                                   | 0.086     | 24.49       |
@@ -16,7 +16,7 @@
 | ErrorHandler                            | 0.086     | 24.49       |
 | FastFinalityTracking                    | 6.312     | 18.264      |
 | Forwarder                               | 3.816     | 20.76       |
-| GeneralConfig                           | 34.714    | -10.138     |
+| GeneralConfig                           | 33.891    | -9.315      |
 | GlobalProposal                          | 0.166     | 24.41       |
 | HasBridgeDeprecated                     | 0.063     | 24.513      |
 | HasBridgeTrackingDeprecated             | 0.063     | 24.513      |
@@ -74,8 +74,8 @@
 | MockProfile                             | 12.79     | 11.786      |
 | MockRONTransferHelperConsumer_Berlin    | 0.442     | 24.134      |
 | MockRONTransferHelperConsumer_Istanbul  | 0.442     | 24.134      |
-| MockRoninValidatorSetExtended           | 28.974    | -4.398      |
-| MockRoninValidatorSetOverridePrecompile | 28.197    | -3.621      |
+| MockRoninValidatorSetExtended           | 27.99     | -3.414      |
+| MockRoninValidatorSetOverridePrecompile | 27.213    | -2.637      |
 | MockSlashIndicatorExtended              | 19.067    | 5.509       |
 | MockSorting                             | 3.165     | 21.411      |
 | MockStaking                             | 4.859     | 19.717      |
@@ -94,7 +94,8 @@
 | RoninRandomBeacon_Mainnet               | 17.619    | 6.957       |
 | RoninRandomBeacon_Testnet               | 19.987    | 4.589       |
 | RoninTrustedOrganization                | 10.372    | 14.204      |
-| RoninValidatorSet                       | 24.124    | 0.452       |
+| RoninValidatorSet                       | 23.156    | 1.42        |
+| RoninValidatorSetConstructor            | 13.755    | 10.821      |
 | RoninValidatorSetREP10Migrator          | 2.957     | 21.619      |
 | RoninValidatorSetTimedMigrator          | 3.602     | 20.974      |
 | Safe                                    | 13.651    | 10.925      |
@@ -103,7 +104,7 @@
 | SlashIndicator                          | 15.407    | 9.169       |
 | Sorting                                 | 0.086     | 24.49       |
 | Staking                                 | 22.45     | 2.126       |
-| StakingVesting                          | 3.483     | 21.093      |
+| StakingVesting                          | 4.151     | 20.425      |
 | StdStyle                                | 0.086     | 24.49       |
 | StorageSlot                             | 0.086     | 24.49       |
 | Strings                                 | 0.086     | 24.49       |

--- a/test/foundry/libraries/LibArray.t.sol
+++ b/test/foundry/libraries/LibArray.t.sol
@@ -3,8 +3,88 @@ pragma solidity ^0.8.0;
 
 import { Test } from "forge-std/Test.sol";
 import { LibArray } from "@ronin/contracts/libraries/LibArray.sol";
+import { console } from "forge-std/console.sol";
 
 contract LibArrayTest is Test {
+  function testConcrete_findNormalizedPivotAndSum() public view {
+    address[] memory cids = new address[](13);
+    for (uint256 i; i < cids.length; ++i) {
+      cids[i] = address(uint160(i));
+    }
+    uint256[] memory stakedAmounts = new uint256[](13);
+
+    stakedAmounts[0] = 17585 ether;
+    stakedAmounts[1] = 50090 ether;
+    stakedAmounts[2] = 16137 ether;
+    stakedAmounts[3] = 14543 ether;
+    stakedAmounts[4] = 16855 ether;
+    stakedAmounts[5] = 23005 ether;
+    stakedAmounts[6] = 15709 ether;
+    stakedAmounts[7] = 7988 ether;
+    stakedAmounts[8] = 14511 ether;
+    stakedAmounts[9] = 14511 ether;
+    stakedAmounts[10] = 14501 ether;
+    stakedAmounts[11] = 9502 ether;
+    stakedAmounts[12] = 15061 ether;
+
+    address[] memory oriCids = new address[](13);
+    address[] memory expectedSortedCids = new address[](13);
+    expectedSortedCids[0] = 0x0000000000000000000000000000000000000001;
+    expectedSortedCids[1] = 0x0000000000000000000000000000000000000005;
+    expectedSortedCids[2] = 0x0000000000000000000000000000000000000000;
+    expectedSortedCids[3] = 0x0000000000000000000000000000000000000004;
+    expectedSortedCids[4] = 0x0000000000000000000000000000000000000002;
+    expectedSortedCids[5] = 0x0000000000000000000000000000000000000006;
+    expectedSortedCids[6] = 0x000000000000000000000000000000000000000C;
+    expectedSortedCids[7] = 0x0000000000000000000000000000000000000003;
+    expectedSortedCids[8] = 0x0000000000000000000000000000000000000009;
+    expectedSortedCids[9] = 0x0000000000000000000000000000000000000008;
+    expectedSortedCids[10] = 0x000000000000000000000000000000000000000A;
+    expectedSortedCids[11] = 0x000000000000000000000000000000000000000b;
+    expectedSortedCids[12] = 0x0000000000000000000000000000000000000007;
+    for (uint256 i; i < 13; ++i) {
+      oriCids[i] = cids[i];
+    }
+
+    (uint256 normSum, uint256 pivot) = LibArray.inplaceFindNormalizedSumAndPivot(cids, stakedAmounts, 10);
+    console.log("Pivot", pivot);
+
+    uint256[] memory expectedSortedStakedAmounts = new uint256[](13);
+    expectedSortedStakedAmounts[0] = 50090000000000000000000;
+    expectedSortedStakedAmounts[1] = 23005000000000000000000;
+    expectedSortedStakedAmounts[2] = 17585000000000000000000;
+    expectedSortedStakedAmounts[3] = 16855000000000000000000;
+    expectedSortedStakedAmounts[4] = 16137000000000000000000;
+    expectedSortedStakedAmounts[5] = 15709000000000000000000;
+    expectedSortedStakedAmounts[6] = 15061000000000000000000;
+    expectedSortedStakedAmounts[7] = 14543000000000000000000;
+    expectedSortedStakedAmounts[8] = 14511000000000000000000;
+    expectedSortedStakedAmounts[9] = 14511000000000000000000;
+    expectedSortedStakedAmounts[10] = 14501000000000000000000;
+    expectedSortedStakedAmounts[11] = 9502000000000000000000;
+    expectedSortedStakedAmounts[12] = 7988000000000000000000;
+    console.log("Norm Sum", normSum);
+
+    for (uint256 i; i < 13; ++i) {
+      console.log("cids", vm.toString(cids[i]), vm.toString(stakedAmounts[i]));
+    }
+    // Assert Order between stakedAmounts and cids are sorted together in descending order
+    for (uint256 i; i < 12; ++i) {
+      assertTrue(stakedAmounts[i] >= stakedAmounts[i + 1], "stakedAmounts[i] >= stakedAmounts[i + 1]");
+      assertTrue(cids[i] == oriCids[uint256(uint160(cids[i]))], "cids[i] == oriCids[uint256(uint160(cids[i]))]");
+    }
+
+    for (uint256 i; i < expectedSortedCids.length; ++i) {
+      assertTrue(cids[i] == expectedSortedCids[i], "cids[i] == expectedSortedCids[i]");
+      assertTrue(
+        stakedAmounts[i] == expectedSortedStakedAmounts[i], "stakedAmounts[i] == expectedSortedStakedAmounts[i]"
+      );
+    }
+
+    assertEq(pivot, 19612875000000000000000, "incorrect expected pivot");
+    assertEq(normSum, 196128750000000000000000, "incorrect expected normSum");
+  }
+
   function testFuzz_AddAndSum(uint256[1000] memory arr1_, uint256[1000] memory arr2_) public pure {
     uint256[] memory arr1 = new uint256[](arr1_.length);
     uint256[] memory arr2 = new uint256[](arr2_.length);


### PR DESCRIPTION
### Description
Root cause: 
- Modified `stakedAmounts` array after entering function `LibArray.findNormalizedSumAndPivot` resulted in invalid normalized staked data storing.

Specifically:
```solidity
// This function resulted in corrupted order of array `stakeAmounts`, which caused mapping for loop incorrectly store normalized stake amount of candidates.
 (normalizedSum_, pivot) =
  LibArray.findNormalizedSumAndPivot({ values: stakeAmounts, divisor: validator.maxValidatorNumber() });

uint256[] memory normalizedStakeAmounts = LibArray.inplaceClip({ values: stakeAmounts, lower: 0, upper: pivot });

for (uint256 i; i < allCids.length; ++i) {
  $normalizedData.normalizedStake[allCids[i]] = normalizedStakeAmounts[i];
}
``` 
```solidity
function findNormalizedSumAndPivot(
    uint256[] memory values,
    uint256 divisor
  ) internal pure returns (uint256 normSum, uint256 pivot) {
    divisor = Math.min(values.length, divisor);
   // This line modifies element positions in `values` array.
    values = inplaceDescSort(values);
........
``` 